### PR TITLE
Respect selected architecture when the binary is fat

### DIFF
--- a/install_pythonw.py
+++ b/install_pythonw.py
@@ -55,6 +55,7 @@ def main(env_path, script_path):
     pythonw_dest = path.join(env_path, 'bin', 'pythonw')
     call([
         'cc',
+        '-arch', 'i386', '-arch', 'x86_64',
         '-DPYTHONWEXECUTABLE="' + pythonw_executable + '"',
         '-o',
         pythonw_dest,

--- a/pythonw.c
+++ b/pythonw.c
@@ -5,13 +5,20 @@
  * application bundle.
  */
 #include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
 #include <err.h>
 
 static char Python[] = PYTHONWEXECUTABLE;
 
 int main(int argc, char **argv) {
-	argv[0] = Python;
-	execv(Python, argv);
-	err(1, "execv: %s", Python);
-	/* NOTREACHED */
+     char **a;
+     a = malloc((argc + 2) * sizeof(char *));
+     memcpy(a + 2, argv, argc * sizeof(char *));
+     a[0] = "/usr/bin/arch";
+     a[1] = sizeof(char *) == 4 ? "-i386" : "-x86_64";
+     a[2] = Python;
+     execv("/usr/bin/arch", a);
+     err(1, "execv: %s", "arch");
+     /* NOTREACHED */
 }


### PR DESCRIPTION
Previously, if the pythonw in the virtualenv was started with
`arch -i386 virtualenv`, this was not carried through to the underlying
binary. Now, check for architecture and exec /usr/bin/arch to choose.
