### PR TITLE
Fix for Yosemite

### DIFF
--- a/pythonw.c
+++ b/pythonw.c
@@ -13,11 +13,12 @@ static char Python[] = PYTHONWEXECUTABLE;
 
 int main(int argc, char **argv) {
      char **a;
-     a = malloc((argc + 2) * sizeof(char *));
+     a = malloc((argc + 3) * sizeof(char *));
      memcpy(a + 2, argv, argc * sizeof(char *));
      a[0] = "/usr/bin/arch";
      a[1] = sizeof(char *) == 4 ? "-i386" : "-x86_64";
      a[2] = Python;
+     a[argc+2] = NULL;
      execv("/usr/bin/arch", a);
      err(1, "execv: %s", "arch");
      /* NOTREACHED */


### PR DESCRIPTION
Need to add a NULL for execv argument for Yosemite. Otherwise a "Bad address" error is raised.