### PR TITLE
PIP-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+#### joe made this: https://goel.io/joe
+
+#####=== Python ===#####
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include install_pythonw/pythonw.c

--- a/install_pythonw/__init__.py
+++ b/install_pythonw/__init__.py
@@ -55,7 +55,13 @@ virtualenvs based on OSX Framework-style installs.
 
 """
 
-def main(env_path, script_path):
+def main(argv):
+    if len(argv) != 2:
+        print USAGE
+        sys.exit(1)
+    env_path = path.abspath(argv[1])
+    script_path = path.abspath(path.dirname(__file__))
+
     # If Python.app already exists, exit.
     python_app_dest = path.join(env_path, 'Python.app')
     if path.exists(python_app_dest):
@@ -110,10 +116,9 @@ def main(env_path, script_path):
     print "finished!  App bundle created at:  " + python_app_dest
 
 
+def run_main():
+    sys.exit(main(sys.argv))
+
+
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print USAGE
-        sys.exit(1)
-    env_path = path.abspath(sys.argv[1])
-    script_path = path.abspath(path.dirname(sys.argv[0]))
-    sys.exit(main(env_path, script_path))
+    run_main()

--- a/install_pythonw/pythonw.c
+++ b/install_pythonw/pythonw.c
@@ -13,11 +13,12 @@ static char Python[] = PYTHONWEXECUTABLE;
 
 int main(int argc, char **argv) {
      char **a;
-     a = malloc((argc + 2) * sizeof(char *));
+     a = malloc((argc + 3) * sizeof(char *));
      memcpy(a + 2, argv, argc * sizeof(char *));
      a[0] = "/usr/bin/arch";
      a[1] = sizeof(char *) == 4 ? "-i386" : "-x86_64";
      a[2] = Python;
+     a[argc+2] = NULL;
      execv("/usr/bin/arch", a);
      err(1, "execv: %s", "arch");
      /* NOTREACHED */

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name='fix-osx-virtualenv',
+    version="0.1",
+    description='Fixes virtualenvs on Mac OSX to be GUI friendly',
+    long_description="",
+    license='MIT',
+    author='Matthew Scott and Contributors',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: MacOS :: MacOS X',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+    ],
+    packages=['install_pythonw'],
+    entry_points={
+        'console_scripts': ['fix-osx-virtualenv = install_pythonw:run_main'],
+    },
+    package_data={'install_pythonw': [
+        'pythonw.c',
+    ]},
+)


### PR DESCRIPTION
This PR implements a simple setup.py file that makes the project `pip install` able and registers an executable `fix-osx-virtualenv` so you don't have to remember where you git cloned the project to.
