### PR TITLE
Fix [?] usage documentation by using `fix-osx-virtualenv`

### DIFF
--- a/install_pythonw/__init__.py
+++ b/install_pythonw/__init__.py
@@ -28,18 +28,18 @@ PYTHON_ARCH = 8 * struct.calcsize("P")
 ARCHS = {32:'i386',64:'x86_64'}
 
 USAGE = """
-Usage: install_pythonw.py ROOT_OF_PARTICULAR_VIRTUALENV
+Usage: fix-osx-virtualenv ROOT_OF_PARTICULAR_VIRTUALENV
 (if you are in the virtualenv right now, try:
 
     $ which python
 
 for me: /Users/me/venvs/py27/bin/python
 
-    $ python install_pythonw.py /Users/me/venvs/py27/
+    $ fix-osx-virtualenv /Users/me/venvs/py27/
 
 or
 
-    $ python install_pythonw.py `which python`/../..
+    $ fix-osx-virtualenv `which python`/../..
 
 
 """


### PR DESCRIPTION
As seen in #11 the current usage string is confusing. As far as I can tell, that `install_pythonw.py` is simply a remnant from some older version, but I really don’t know.

By the way, thank you very, very much for this. I think you’ve saved me hours of pain.
